### PR TITLE
add og:image in metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,10 +14,16 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const DEFAULT_BASE_URL = "https://vote.shu-kita.net";
+
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"),
+  metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL || DEFAULT_BASE_URL),
   title: "TOHYO通信 ~Vote Communication~",
   description: "プレゼンテーションやイベントで使用するリアルタイム投票Webアプリケーション",
+  twitter: {
+    card: "summary_large_image",
+    images: ["/twitter-image.png"],
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
This pull request introduces a default base URL for metadata and adds Twitter card metadata to improve social sharing capabilities.

Metadata improvements:

* Added a `DEFAULT_BASE_URL` constant and updated the `metadataBase` property to use it as a fallback when `NEXT_PUBLIC_BASE_URL` is not set.
* Added a `twitter` property to the metadata, specifying a large summary card and an image for Twitter sharing.