### PR TITLE
Avoid participant SSE refetch amplification

### DIFF
--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -36,6 +36,8 @@ GET /api/rooms/:roomId/events
 
 Workerは接続時にD1から最新snapshotを取得し、DOへ投入してからSSE streamを返します。これにより、DOがevictされていても次の接続で復元できます。
 
+参加者接続では、Workerが匿名セッションCookieから回答済み質問IDをD1で取得し、DOへ接続ごとの公開範囲として渡します。回答済み質問が増えた投票成功後だけブラウザがSSE接続を張り直します。
+
 ## Snapshot形式
 
 実装上の型は [`src/shared/room-snapshot.ts`](../src/shared/room-snapshot.ts) にあります。
@@ -62,6 +64,7 @@ DOは接続時のaudienceに応じてpayloadを分けます。
 | `participant` | 回答済み質問の結果だけ含む |
 
 ゲストが未回答の質問については、結果を配信しません。投票後は該当質問の結果が見えるようになります。
+参加者はSSE payloadを直接画面へ反映するため、通知ごとにルームAPIを再取得しません。
 
 ## stateVersion
 

--- a/docs/skill-output/PLAN.md
+++ b/docs/skill-output/PLAN.md
@@ -1,86 +1,87 @@
-# 実装計画: V1実装と旧構成参照の削除
+# 実装計画: 参加者別SSE snapshot配信
 
 ## 概要
 
-現行のCloudflare Workers + Hono + React/Vite + D1構成だけでリポジトリを理解できるようにする。旧Next.js/OpenNext実装を削除し、ドキュメントとツール設定を現行構成へ統一する。
+回答済み参加者が `room.snapshot` を受信するたびにルームAPIを再取得する挙動を廃止する。Workerが匿名セッションから回答済み質問を判定し、Durable Objectが接続ごとの公開範囲でsnapshotを配信する。
 
 ## 要件
 
-- `legacy/` 配下のV1実装を削除する
-- `AGENTS.md` と `README.md` を現行仕様へ更新する
-- Next.js/OpenNext/V1専用の設定とAI向けガイドを整理する
-- `wrangler.jsonc` のDurable Object migration履歴は維持する
-- 現行実装のcheck、test、E2E、buildが成功することを確認する
+- 投票済み参加者のSSE受信による `GET /api/rooms/:roomId` 増幅をなくす
+- 回答済み質問の結果はリアルタイム更新する
+- 未回答質問の結果は参加者へ公開しない
+- ホスト向け全結果配信と未投票参加者向け配信を維持する
 
 ## アーキテクチャ変更
 
-- `legacy/`: 旧Next.js/OpenNext実装一式を削除する
-- `AGENTS.md`: React/Vite/Hono/D1/RoomEventsDO構成と現行ルート・機能へ更新する
-- `README.md`: 旧実装の退避説明とディレクトリ項目を削除する
-- `.gitignore`, `.oxlintrc.json`, `.oxfmtrc.json`, `tsconfig.json`: V1専用除外を削除する
-- `.codex/skills/code-review/SKILL.md`: レビュー対象と観点を現行技術スタックへ更新する
+- `src/server/index.ts`: SSE接続時にCookieとD1から回答済み質問IDを取得し、DOへ渡す
+- `src/durable-objects/room-events.ts`: 接続ごとに回答済み質問IDを保持してsnapshotを絞り込む
+- `src/client/pages/room-page.tsx`: SSE payloadを直接反映し、投票成功後だけ接続を張り直す
+- `docs/realtime.md`: 参加者別公開範囲と投票後再接続を記録する
+- `tests/worker/voting-flow.test.ts`: SSEの結果公開範囲とリアルタイム更新を検証する
+- `tests/e2e/room.spec.ts`: SSE更新でルームAPIが再取得されないことを検証する
 
 ## 実装手順
 
-### フェーズ1: 旧実装と参照の整理
+### フェーズ1: 配信経路
 
-1. **V1実装を削除する** (File: `legacy/`)
-   - Action: 旧Next.js/OpenNextのコード、設定、依存関係、テストを削除する
-   - Why: 現行実装との誤認を防ぐため
+1. **Workerで公開範囲を決定する** (File: `src/server/index.ts`)
+   - Action: 参加者の匿名セッションCookieから回答済み質問IDを取得し、DO内部リクエストへ付与する
+   - Why: ブラウザ申告による未回答結果の取得を防ぐため
    - Dependencies: なし
-   - Risk: 低（削除対象が明示されている）
+   - Risk: 中
 
-2. **プロジェクトガイドを更新する** (File: `AGENTS.md`, `README.md`)
-   - Action: 現行のルーム、認証、D1永続化、RoomEventsDOによるSSE配信を説明する
-   - Why: 開発者とAIが現行仕様だけを参照できるようにするため
-   - Dependencies: 現行ドキュメントと実装の確認
-   - Risk: 中（仕様記述の不一致）
-
-3. **V1専用設定を削除する** (File: `.gitignore`, `.oxlintrc.json`, `.oxfmtrc.json`, `tsconfig.json`)
-   - Action: Next.js、OpenNext、legacy向けの除外設定を削除する
-   - Why: 不要な設定を残さず、検索やチェック対象を明確にするため
+2. **接続別snapshotを生成する** (File: `src/durable-objects/room-events.ts`)
+   - Action: SSEクライアントごとに回答済み質問IDを保持し、`snapshotForAudience` へ渡す
+   - Why: 同じroomの参加者ごとに異なる結果公開範囲を適用するため
    - Dependencies: ステップ1
-   - Risk: 低
+   - Risk: 中
 
-4. **コードレビュースキルを更新する** (File: `.codex/skills/code-review/SKILL.md`)
-   - Action: Next.js固有の対象・観点をReact/Vite/Hono/D1へ置き換える
-   - Why: AI向けガイドが旧構成を前提にしないようにするため
-   - Dependencies: なし
-   - Risk: 低
+3. **クライアント再取得を廃止する** (File: `src/client/pages/room-page.tsx`)
+   - Action: SSE snapshotを直接反映し、投票成功後のみEventSourceを再接続する
+   - Why: 参加者数と投票数に比例するルームAPI再取得を除去するため
+   - Dependencies: ステップ1、2
+   - Risk: 中
 
 ### フェーズ2: 検証
 
-1. **残存参照を検索する** (File: repository-wide)
-   - Action: V1ルート、Next.js、OpenNext、legacy参照を検索し、migration履歴と生成型以外が残っていないことを確認する
-   - Why: 削除漏れを防ぐため
+1. **Workerテストを追加する** (File: `tests/worker/voting-flow.test.ts`)
+   - Action: 回答済み結果だけがSSE配信され、その後の投票でリアルタイム更新されることを検証する
+   - Why: サーバー側の公開範囲を保証するため
    - Dependencies: フェーズ1
-   - Risk: 低
+   - Risk: 中
 
-2. **品質チェックを実行する** (File: repository-wide)
-   - Action: `pnpm check`, `pnpm test`, `pnpm test:e2e`, `pnpm build` を実行する
-   - Why: 現行実装へ影響がないことを確認するため
+2. **E2Eテストを追加する** (File: `tests/e2e/room.spec.ts`)
+   - Action: 投票後のSSE通知で参加者ルームAPIのGET回数が増えないことを検証する
+   - Why: 再取得増幅の回帰を防ぐため
    - Dependencies: フェーズ1
-   - Risk: 中（ブラウザやローカル環境依存）
+   - Risk: 中
+
+3. **全品質チェックを実行する** (File: repository-wide)
+   - Action: `pnpm check`, `pnpm test`, `pnpm test:e2e`, `pnpm build` を実行する
+   - Why: 型、配信、投票フロー、ビルドへの回帰がないことを確認するため
+   - Dependencies: フェーズ2
+   - Risk: 中
 
 ## テスト戦略
 
-- 静的検査: lint、format、TypeScript typecheck
-- ユニット/結合テスト: Vitest Workers Poolの全テスト
-- E2Eテスト: Playwrightでルーム作成・投票フロー
-- ビルド: Vite + Cloudflare Worker本番ビルド
-- 残存参照: `rg` による旧構成キーワード検索
+- ユニットテスト: 既存の `snapshotForAudience` 公開範囲テストを維持する
+- Workerテスト: Cookie由来の回答済み質問だけをSSEで公開し、票数更新を受信する
+- E2Eテスト: 投票後のSSE更新でルームAPI再取得が発生しないことを数える
+- 全体検証: check、test、E2E、build
 
 ## リスクと対策
 
-- **Risk**: migration履歴の `VoteSessionDO` を誤って削除する
-  - Mitigation: `wrangler.jsonc` のv1/v2 migrationは変更せず、差分と検索結果で確認する
-- **Risk**: 現行機能を旧実装と誤認して削除する
-  - Mitigation: `src/`, `docs/`, `tests/` の現行ルームAPIとSSE設計を基準に判定する
+- **Risk**: 投票直後に古い公開範囲のSSEがPOSTレスポンスを上書きする
+  - Mitigation: 古いEventSourceを無効化してからPOST snapshotを反映し、新しい公開範囲で再接続する
+- **Risk**: 回答済み質問IDをクエリ改ざんされる
+  - Mitigation: 公開URLの入力を使わず、WorkerがCookieとD1から決定してDO内部URLへ渡す
+- **Risk**: host接続で結果が欠落する
+  - Mitigation: host audienceは従来どおり全snapshotを返し、Workerテストで確認する
 
 ## 成功基準
 
-- [x] `legacy/` が削除されている
-- [x] 現行ドキュメントとAI向けガイドに旧構成の説明が残っていない
-- [x] Next.js/OpenNext/V1専用設定が削除されている
-- [x] `wrangler.jsonc` の `VoteSessionDO` migration履歴が維持されている
-- [ ] `pnpm check`, `pnpm test`, `pnpm test:e2e`, `pnpm build` が成功する
+- [x] SSE受信時に参加者ルームAPIを再取得しない
+- [x] 回答済み質問の結果がSSEで更新される
+- [x] 未回答質問の結果がSSEに含まれない
+- [x] ホストのリアルタイム更新が維持される
+- [x] `pnpm check`, `pnpm test`, `pnpm test:e2e`, `pnpm build` が成功する

--- a/src/client/pages/room-page.tsx
+++ b/src/client/pages/room-page.tsx
@@ -176,6 +176,7 @@ export function RoomPage({ onHostAuthenticated }: RoomPageProps = {}) {
         try {
           const response = await requestJson<unknown>(`/api/rooms/${roomId}`);
           const parsed = participantRoomResponseSchema.parse(response);
+          reconnectEventSourceRef.current();
           setVotedQuestionIds(parsed.votedQuestionIds);
           setSnapshot(parsed.snapshot);
         } catch {

--- a/src/client/pages/room-page.tsx
+++ b/src/client/pages/room-page.tsx
@@ -31,11 +31,11 @@ export function RoomPage({ onHostAuthenticated }: RoomPageProps = {}) {
   const [isHostAuthenticating, setIsHostAuthenticating] = useState(false);
   const [isHostAccessOpen, setIsHostAccessOpen] = useState(false);
   const [error, setError] = useState("");
-  const votedQuestionIdsRef = useRef<string[]>([]);
+  const eventSourceRef = useRef<EventSource | undefined>(undefined);
+  const reconnectEventSourceRef = useRef<() => void>(() => undefined);
 
   useEffect(() => {
     let isCancelled = false;
-    let eventSource: EventSource | undefined;
 
     const refreshRoom = async () => {
       try {
@@ -48,7 +48,6 @@ export function RoomPage({ onHostAuthenticated }: RoomPageProps = {}) {
 
         setRoomTitle(parsed.title);
         setVotedQuestionIds(parsed.votedQuestionIds);
-        votedQuestionIdsRef.current = parsed.votedQuestionIds;
         setSnapshot(parsed.snapshot);
       } catch (loadError) {
         if (!isCancelled) {
@@ -60,30 +59,51 @@ export function RoomPage({ onHostAuthenticated }: RoomPageProps = {}) {
       }
     };
 
+    const connectEventSource = () => {
+      const previousEventSource = eventSourceRef.current;
+      const eventSource = new EventSource(`/api/rooms/${roomId}/events`);
+      eventSourceRef.current = eventSource;
+      previousEventSource?.close();
+      setConnectionStatus("connecting");
+
+      eventSource.onopen = () => {
+        if (eventSourceRef.current === eventSource) {
+          setConnectionStatus("connected");
+        }
+      };
+      eventSource.onerror = () => {
+        if (eventSourceRef.current === eventSource) {
+          setConnectionStatus("disconnected");
+        }
+      };
+      eventSource.addEventListener("room.snapshot", (event) => {
+        if (eventSourceRef.current !== eventSource) {
+          return;
+        }
+
+        const message = event as MessageEvent<string>;
+
+        try {
+          const snapshotResult = roomSnapshotSchema.safeParse(JSON.parse(message.data));
+
+          if (snapshotResult.success) {
+            setSnapshot(snapshotResult.data);
+          }
+        } catch {
+          setConnectionStatus("disconnected");
+        }
+      });
+    };
+
+    reconnectEventSourceRef.current = connectEventSource;
+
     const connect = async () => {
       try {
         await refreshRoom();
 
-        eventSource = new EventSource(`/api/rooms/${roomId}/events`);
-        eventSource.onopen = () => setConnectionStatus("connected");
-        eventSource.onerror = () => setConnectionStatus("disconnected");
-        eventSource.addEventListener("room.snapshot", (event) => {
-          const message = event as MessageEvent<string>;
-
-          try {
-            const snapshotResult = roomSnapshotSchema.safeParse(JSON.parse(message.data));
-
-            if (snapshotResult.success) {
-              if (votedQuestionIdsRef.current.length > 0) {
-                void refreshRoom();
-              } else {
-                setSnapshot(snapshotResult.data);
-              }
-            }
-          } catch {
-            setConnectionStatus("disconnected");
-          }
-        });
+        if (!isCancelled) {
+          connectEventSource();
+        }
       } finally {
         if (!isCancelled) {
           setIsLoading(false);
@@ -95,7 +115,9 @@ export function RoomPage({ onHostAuthenticated }: RoomPageProps = {}) {
 
     return () => {
       isCancelled = true;
-      eventSource?.close();
+      reconnectEventSourceRef.current = () => undefined;
+      eventSourceRef.current?.close();
+      eventSourceRef.current = undefined;
     };
   }, [roomId]);
 
@@ -146,8 +168,8 @@ export function RoomPage({ onHostAuthenticated }: RoomPageProps = {}) {
       });
       const votedSnapshot = roomSnapshotSchema.parse(response.snapshot);
 
+      reconnectEventSourceRef.current();
       setVotedQuestionIds(response.votedQuestionIds);
-      votedQuestionIdsRef.current = response.votedQuestionIds;
       setSnapshot(votedSnapshot);
     } catch (submissionError) {
       if (submissionError instanceof ApiRequestError && submissionError.code === "already_voted") {
@@ -155,7 +177,6 @@ export function RoomPage({ onHostAuthenticated }: RoomPageProps = {}) {
           const response = await requestJson<unknown>(`/api/rooms/${roomId}`);
           const parsed = participantRoomResponseSchema.parse(response);
           setVotedQuestionIds(parsed.votedQuestionIds);
-          votedQuestionIdsRef.current = parsed.votedQuestionIds;
           setSnapshot(parsed.snapshot);
         } catch {
           setError("投票結果を取得できませんでした。");

--- a/src/durable-objects/room-events.ts
+++ b/src/durable-objects/room-events.ts
@@ -11,6 +11,7 @@ const HEARTBEAT_INTERVAL_MS = 15_000;
 interface SseClient {
   audience: SnapshotAudience;
   controller: ReadableStreamDefaultController<Uint8Array>;
+  visibleResultQuestionIds: string[];
 }
 
 export class RoomEventsDO implements DurableObject {
@@ -30,7 +31,11 @@ export class RoomEventsDO implements DurableObject {
     const url = new URL(request.url);
 
     if (request.method === "GET" && url.pathname === "/events") {
-      return this.createEventStream(request, this.readAudience(url));
+      return this.createEventStream(
+        request,
+        this.readAudience(url),
+        url.searchParams.getAll("visibleResultQuestionId"),
+      );
     }
 
     if (request.method === "POST" && url.pathname === "/snapshot") {
@@ -44,12 +49,16 @@ export class RoomEventsDO implements DurableObject {
     return url.searchParams.get("audience") === "host" ? "host" : "participant";
   }
 
-  private createEventStream(request: Request, audience: SnapshotAudience): Response {
+  private createEventStream(
+    request: Request,
+    audience: SnapshotAudience,
+    visibleResultQuestionIds: string[],
+  ): Response {
     let client: SseClient | undefined;
 
     const stream = new ReadableStream<Uint8Array>({
       start: (controller) => {
-        client = { audience, controller };
+        client = { audience, controller, visibleResultQuestionIds };
         this.clients.add(client);
         this.startHeartbeat();
 
@@ -116,7 +125,7 @@ export class RoomEventsDO implements DurableObject {
   }
 
   private sendSnapshot(client: SseClient, snapshot: RoomSnapshot): void {
-    const payload = snapshotForAudience(snapshot, client.audience);
+    const payload = snapshotForAudience(snapshot, client.audience, client.visibleResultQuestionIds);
     const message = [
       `id: ${snapshot.stateVersion}`,
       "event: room.snapshot",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -14,6 +14,7 @@ import { snapshotForAudience } from "../shared/room-snapshot";
 import {
   createHostSession,
   createVoterKeyHash,
+  getAnonymousSessionToken,
   getHostSessionToken,
   getOrCreateAnonymousSession,
   hashAdminPassword,
@@ -897,9 +898,17 @@ app.get(
     await notifyRoomSnapshot(c.env, roomState.snapshot);
 
     const audience = (await isAuthorizedHost(c, roomId)) ? "host" : "participant";
+    const visibleResultQuestionIds =
+      audience === "participant" ? await getParticipantVotedQuestionIds(c, roomId) : [];
     const roomEvents = c.env.ROOM_EVENTS.getByName(roomId);
+    const eventsUrl = new URL("https://room-events/events");
+    eventsUrl.searchParams.set("audience", audience);
 
-    return roomEvents.fetch(`https://room-events/events?audience=${audience}`, {
+    for (const questionId of visibleResultQuestionIds) {
+      eventsUrl.searchParams.append("visibleResultQuestionId", questionId);
+    }
+
+    return roomEvents.fetch(eventsUrl, {
       headers: c.req.raw.headers,
       signal: c.req.raw.signal,
     });
@@ -959,6 +968,17 @@ async function getVotedQuestionIds(
     .all<{ questionId: string }>();
 
   return votes.results.map((vote) => vote.questionId);
+}
+
+async function getParticipantVotedQuestionIds(c: AppContext, roomId: string): Promise<string[]> {
+  const anonymousToken = getAnonymousSessionToken(c, roomId);
+
+  if (!anonymousToken) {
+    return [];
+  }
+
+  const voterKeyHash = await createVoterKeyHash(roomId, anonymousToken);
+  return getVotedQuestionIds(c.env.DB, roomId, voterKeyHash);
 }
 
 export { RoomEventsDO };

--- a/tests/e2e/room.spec.ts
+++ b/tests/e2e/room.spec.ts
@@ -36,6 +36,14 @@ test("starts a question and accepts a participant vote", async ({ browser, page 
   const participantPage = await browser.newPage({
     baseURL: new URL(page.url()).origin,
   });
+  let participantRoomRequestCount = 0;
+  participantPage.on("request", (request) => {
+    const url = new URL(request.url());
+
+    if (request.method() === "GET" && url.pathname === `/api/rooms/${roomId}`) {
+      participantRoomRequestCount += 1;
+    }
+  });
   await participantPage.goto(`/rooms/${roomId}`);
   await expect(
     participantPage.getByRole("heading", {
@@ -121,6 +129,8 @@ test("starts a question and accepts a participant vote", async ({ browser, page 
   await expect(participantFirstQuestion.getByLabel("ユーザーリサーチ: 0票、0%")).toBeVisible();
   await expect(firstQuestionCard.getByLabel("プロトタイピング: 1票、100%")).toBeVisible();
   await expect(firstQuestionCard.getByLabel("ユーザーリサーチ: 0票、0%")).toBeVisible();
+  const participantRoomRequestsAfterVote = participantRoomRequestCount;
+  expect(participantRoomRequestsAfterVote).toBeGreaterThan(0);
 
   page.once("dialog", (confirmation) => confirmation.accept());
   await firstQuestionCard.getByRole("button", { name: "投票を終了" }).click();
@@ -131,6 +141,7 @@ test("starts a question and accepts a participant vote", async ({ browser, page 
   await expect(
     participantFirstQuestion.getByText("受付は終了しました。最終結果です。"),
   ).toBeVisible();
+  expect(participantRoomRequestCount).toBe(participantRoomRequestsAfterVote);
 
   await secondVoteForm.getByLabel("満足").check();
   await secondVoteForm.getByRole("button", { name: "投票する" }).click();
@@ -145,6 +156,7 @@ test("starts a question and accepts a participant vote", async ({ browser, page 
     participantPage.getByRole("heading", { name: "この投票ルームは終了しました" }),
   ).toBeVisible();
   await expect(secondVoteForm).toHaveCount(0);
+  expect(participantRoomRequestCount).toBe(participantRoomRequestsAfterVote);
 
   await participantPage.close();
 });

--- a/tests/worker/voting-flow.test.ts
+++ b/tests/worker/voting-flow.test.ts
@@ -2,6 +2,7 @@ import { applyD1Migrations, env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { mutationRequestHeaderName, mutationRequestHeaderValue } from "../../src/shared/api";
+import { roomSnapshotSchema, type RoomSnapshot } from "../../src/shared/room-snapshot";
 
 interface TestEnv extends Env {
   TEST_MIGRATIONS: Array<{
@@ -202,6 +203,54 @@ describe("voting flow", () => {
       },
     });
 
+    const participantEventsResponse = await SELF.fetch(
+      `https://example.com/api/rooms/${room.roomId}/events`,
+      {
+        headers: { Cookie: participantCookie },
+      },
+    );
+    expect(participantEventsResponse.status).toBe(200);
+    const participantEvents = createRoomSnapshotReader(participantEventsResponse);
+    const initialParticipantEvent = await participantEvents.readSnapshot();
+
+    expect(Object.keys(initialParticipantEvent.resultsByQuestion)).toEqual([firstQuestion.id]);
+    expect(initialParticipantEvent.resultsByQuestion[firstQuestion.id]?.voterCount).toBe(1);
+
+    const hostEventsResponse = await SELF.fetch(
+      `https://example.com/api/rooms/${room.roomId}/events`,
+      {
+        headers: { Cookie: hostCookie },
+      },
+    );
+    expect(hostEventsResponse.status).toBe(200);
+    const hostEvents = createRoomSnapshotReader(hostEventsResponse);
+    const initialHostEvent = await hostEvents.readSnapshot();
+
+    expect(Object.keys(initialHostEvent.resultsByQuestion)).toEqual([
+      firstQuestion.id,
+      secondQuestion.id,
+    ]);
+    await hostEvents.cancel();
+
+    const secondParticipantRoomResponse = await SELF.fetch(
+      `https://example.com/api/rooms/${room.roomId}`,
+    );
+    const secondParticipantCookie = readCookie(secondParticipantRoomResponse);
+    const secondParticipantVoteResponse = await SELF.fetch(firstVoteUrl, {
+      body: firstVoteBody,
+      headers: mutationHeaders({
+        "Content-Type": "application/json",
+        Cookie: secondParticipantCookie,
+      }),
+      method: "POST",
+    });
+
+    expect(secondParticipantVoteResponse.status).toBe(201);
+    const updatedParticipantEvent = await participantEvents.readSnapshot();
+    expect(Object.keys(updatedParticipantEvent.resultsByQuestion)).toEqual([firstQuestion.id]);
+    expect(updatedParticipantEvent.resultsByQuestion[firstQuestion.id]?.voterCount).toBe(2);
+    await participantEvents.cancel();
+
     const duplicateVoteResponse = await SELF.fetch(firstVoteUrl, {
       body: firstVoteBody,
       headers: mutationHeaders({
@@ -235,7 +284,7 @@ describe("voting flow", () => {
       expect.objectContaining({ id: firstQuestion.id, status: "closed" }),
       expect.objectContaining({ id: secondQuestion.id, status: "active" }),
     ]);
-    expect(closedQuestionResult.snapshot.resultsByQuestion[firstQuestion.id]?.voterCount).toBe(1);
+    expect(closedQuestionResult.snapshot.resultsByQuestion[firstQuestion.id]?.voterCount).toBe(2);
 
     const voteAfterCloseResponse = await SELF.fetch(firstVoteUrl, {
       body: firstVoteBody,
@@ -275,7 +324,7 @@ describe("voting flow", () => {
     const storedVotes = await testEnv.DB.prepare(
       "SELECT COUNT(*) AS voteCount FROM votes WHERE voter_key_hash IS NOT NULL",
     ).first<{ voteCount: number }>();
-    expect(storedVotes?.voteCount).toBe(2);
+    expect(storedVotes?.voteCount).toBe(3);
 
     const closeRoomResponse = await SELF.fetch(
       `https://example.com/api/rooms/${room.roomId}/close`,
@@ -465,4 +514,54 @@ function readCookie(response: Response): string {
   }
 
   return setCookie.split(";", 1)[0];
+}
+
+function createRoomSnapshotReader(response: Response): {
+  cancel: () => Promise<void>;
+  readSnapshot: () => Promise<RoomSnapshot>;
+} {
+  if (!response.body) {
+    throw new Error("SSE response body was not returned");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  return {
+    cancel: () => reader.cancel(),
+    readSnapshot: async () => {
+      while (true) {
+        const eventBoundary = buffer.indexOf("\n\n");
+
+        if (eventBoundary >= 0) {
+          const event = buffer.slice(0, eventBoundary);
+          buffer = buffer.slice(eventBoundary + 2);
+
+          if (event.includes("event: room.snapshot")) {
+            const data = event
+              .split("\n")
+              .find((line) => line.startsWith("data: "))
+              ?.slice("data: ".length);
+
+            if (!data) {
+              throw new Error("SSE snapshot data was not returned");
+            }
+
+            return roomSnapshotSchema.parse(JSON.parse(data));
+          }
+
+          continue;
+        }
+
+        const chunk = await reader.read();
+
+        if (chunk.done) {
+          throw new Error("SSE stream ended before a snapshot was received");
+        }
+
+        buffer += decoder.decode(chunk.value, { stream: true });
+      }
+    },
+  };
 }


### PR DESCRIPTION
## Summary

- Workerが匿名セッションCookieとD1から回答済み質問IDを決定し、SSE接続ごとの公開範囲としてRoomEventsDOへ渡す
- 参加者は`room.snapshot`を直接反映し、投票成功後だけSSE接続を張り直す
- Workerテストで回答済み結果のみの配信とリアルタイム更新、E2EでSSE通知によるルームAPI再取得が増えないことを検証する

## Testing

- `pnpm check`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`

Closes #38