### PR TITLE
Add Codex issue planning workflow

### DIFF
--- a/.github/workflows/issue-driven-pr.yaml
+++ b/.github/workflows/issue-driven-pr.yaml
@@ -15,15 +15,52 @@ jobs:
     outputs:
       final_message: ${{ steps.run_codex.outputs.final-message }}
     steps:
+      - name: Check issue readiness
+        id: readiness
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const hasRequirements = /(^|\n)#{1,6}\s*(要件|Requirements)\s*(\n|$)/i.test(body);
+            const hasAcceptanceCriteria = /(^|\n)#{1,6}\s*(受入条件|Acceptance Criteria)\s*(\n|$)/i.test(body);
+
+            if (hasRequirements && hasAcceptanceCriteria) {
+              core.setOutput('ready', 'true');
+              return;
+            }
+
+            const missing = [
+              hasRequirements ? null : '要件',
+              hasAcceptanceCriteria ? null : '受入条件',
+            ].filter(Boolean);
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: [
+                'Codex did not start implementation because the Issue is missing required planning sections.',
+                '',
+                `Missing: ${missing.join(', ')}`,
+                '',
+                'Add the missing sections or apply the `codex-plan` label to generate a requirements and acceptance criteria draft before using `codex-autofix`.',
+              ].join('\n'),
+            });
+
+            core.setOutput('ready', 'false');
+
       - name: Checkout repository
+        if: steps.readiness.outputs.ready == 'true'
         uses: actions/checkout@v5
 
       - name: Setup Node.js
+        if: steps.readiness.outputs.ready == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "24"
 
       - name: Set Codex auth.json from secret
+        if: steps.readiness.outputs.ready == 'true'
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
         run: |
@@ -34,10 +71,12 @@ jobs:
           fi
 
       - name: Install Codex CLI
+        if: steps.readiness.outputs.ready == 'true'
         run: |
           npm install -g @openai/codex@latest
 
       - name: Run Codex
+        if: steps.readiness.outputs.ready == 'true'
         id: run_codex
         env:
           GH_TOKEN: ${{ github.token }}
@@ -76,7 +115,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Comment result to issue
-        if: always()
+        if: always() && steps.readiness.outputs.ready == 'true'
         uses: actions/github-script@v7
         env:
           FINAL_MESSAGE: ${{ steps.run_codex.outputs.final-message }}

--- a/.github/workflows/issue-requirements-plan.yaml
+++ b/.github/workflows/issue-requirements-plan.yaml
@@ -3,12 +3,11 @@ name: "Codex Issue Requirements Plan"
 on:
   issues:
     types:
-      - opened
       - labeled
 
 jobs:
   codex-plan:
-    if: github.event.action == 'opened' || (github.event.action == 'labeled' && github.event.label.name == 'codex-plan')
+    if: github.event.label.name == 'codex-plan'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/issue-requirements-plan.yaml
+++ b/.github/workflows/issue-requirements-plan.yaml
@@ -1,0 +1,100 @@
+name: "Codex Issue Requirements Plan"
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  codex-plan:
+    if: github.event.action == 'opened' || (github.event.action == 'labeled' && github.event.label.name == 'codex-plan')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    outputs:
+      final_message: ${{ steps.run_codex.outputs.final-message }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Set Codex auth.json from secret
+        env:
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          if [ -n "${CODEX_AUTH_JSON:-}" ]; then
+            mkdir -p "$HOME/.codex"
+            echo "$CODEX_AUTH_JSON" | tr -d '\n' | base64 -d > "$HOME/.codex/auth.json"
+            chmod 600 "$HOME/.codex/auth.json"
+          fi
+
+      - name: Install Codex CLI
+        run: |
+          npm install -g @openai/codex@latest
+
+      - name: Run Codex requirements plan
+        id: run_codex
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          PROMPT_FILE="$RUNNER_TEMP/codex-plan-prompt.txt"
+          FINAL_MESSAGE_FILE="$RUNNER_TEMP/codex-plan-final-message.txt"
+
+          {
+            printf '%s\n\n' '次のIssue内容を元に、実装前に必要な要件と受入条件を整理してください。'
+            printf '%s\n' 'コード変更、ブランチ作成、コミット、push、Pull Request作成は行わないでください。'
+            printf '%s\n' '処理結果はIssueコメントとしてそのまま投稿できるMarkdownで出力してください。'
+            printf '%s\n' '以下を必ず含めてください。'
+            printf '%s\n' '- 整理された要件'
+            printf '%s\n' '- チェック可能な受入条件'
+            printf '%s\n' '- 実装前に確認が必要な不足点や曖昧な点'
+            printf '%s\n\n' '- 不足点がない場合は、その旨'
+            printf '%s\n' '# Issue情報'
+            printf -- '- Number: #%s\n' "$ISSUE_NUMBER"
+            printf -- '- Title: %s\n' "$ISSUE_TITLE"
+            printf -- '- URL: %s\n\n' "$ISSUE_URL"
+            printf '%s\n' '# Issue本文'
+            printf '%s\n' "$ISSUE_BODY"
+          } > "$PROMPT_FILE"
+
+          codex exec \
+            --dangerously-bypass-approvals-and-sandbox \
+            --output-last-message "$FINAL_MESSAGE_FILE" \
+            < "$PROMPT_FILE"
+
+          delimiter="codex-plan-$(cat /proc/sys/kernel/random/uuid)"
+          while grep -Fqx "$delimiter" "$FINAL_MESSAGE_FILE"; do
+            delimiter="codex-plan-$(cat /proc/sys/kernel/random/uuid)"
+          done
+
+          {
+            printf 'final-message<<%s\n' "$delimiter"
+            cat "$FINAL_MESSAGE_FILE"
+            printf '\n%s\n' "$delimiter"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment requirements plan to issue
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          FINAL_MESSAGE: ${{ steps.run_codex.outputs.final-message }}
+        with:
+          script: |
+            const body = process.env.FINAL_MESSAGE
+              ? `Codex requirements plan completed.\n\n${process.env.FINAL_MESSAGE}`
+              : 'Codex requirements plan did not return a final message. Please check the workflow logs.';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body,
+            });

--- a/docs/skill-output/PLAN.md
+++ b/docs/skill-output/PLAN.md
@@ -1,87 +1,74 @@
-# 実装計画: 参加者別SSE snapshot配信
+# 実装計画: Issue要件定義ワークフロー
 
 ## 概要
 
-回答済み参加者が `room.snapshot` を受信するたびにルームAPIを再取得する挙動を廃止する。Workerが匿名セッションから回答済み質問を判定し、Durable Objectが接続ごとの公開範囲でsnapshotを配信する。
+Issue #47では、実装前にIssueの要件と受入条件を整理する自動処理を追加する。既存の`codex-autofix`による実装PR作成とは別の`codex-plan`トリガーを用意し、要件定義と実装開始の責務を分離する。
 
 ## 要件
 
-- 投票済み参加者のSSE受信による `GET /api/rooms/:roomId` 増幅をなくす
-- 回答済み質問の結果はリアルタイム更新する
-- 未回答質問の結果は参加者へ公開しない
-- ホスト向け全結果配信と未投票参加者向け配信を維持する
+- Issue作成時、または`codex-plan`ラベル付与時に要件定義処理を起動する。
+- 対象Issueの番号、URL、タイトル、本文をCodex処理へ渡す。
+- 整理された要件、受入条件、不足点をIssueコメントとして残す。
+- `codex-autofix`の実装PR作成フローとトリガーを混同しない。
+- 不十分なIssue本文で`codex-autofix`が不用意に実装へ進まないようにする。
 
 ## アーキテクチャ変更
 
-- `src/server/index.ts`: SSE接続時にCookieとD1から回答済み質問IDを取得し、DOへ渡す
-- `src/durable-objects/room-events.ts`: 接続ごとに回答済み質問IDを保持してsnapshotを絞り込む
-- `src/client/pages/room-page.tsx`: SSE payloadを直接反映し、投票成功後だけ接続を張り直す
-- `docs/realtime.md`: 参加者別公開範囲と投票後再接続を記録する
-- `tests/worker/voting-flow.test.ts`: SSEの結果公開範囲とリアルタイム更新を検証する
-- `tests/e2e/room.spec.ts`: SSE更新でルームAPIが再取得されないことを検証する
+- `.github/workflows/issue-requirements-plan.yaml`: `opened`または`codex-plan`ラベルを契機に、要件定義専用のCodex実行とIssueコメント投稿を行う。
+- `.github/workflows/issue-driven-pr.yaml`: 実装前にIssue本文が要件・受入条件を含むか確認し、不足時はコメントして実装をスキップする。
 
 ## 実装手順
 
-### フェーズ1: 配信経路
+### フェーズ1: 要件定義ワークフロー追加
 
-1. **Workerで公開範囲を決定する** (File: `src/server/index.ts`)
-   - Action: 参加者の匿名セッションCookieから回答済み質問IDを取得し、DO内部リクエストへ付与する
-   - Why: ブラウザ申告による未回答結果の取得を防ぐため
+1. **専用Workflowの作成** (File: `.github/workflows/issue-requirements-plan.yaml`)
+   - Action: `issues.opened`と`issues.labeled`を監視し、`opened`または`codex-plan`ラベル時だけ実行する。
+   - Why: Issue作成と要件定義ラベルの両方を入口にできるようにするため。
+   - Dependencies: なし
+   - Risk: 低
+
+2. **Codex入力の明示化** (File: `.github/workflows/issue-requirements-plan.yaml`)
+   - Action: Issue番号、URL、タイトル、本文を環境変数経由でプロンプトに含める。
+   - Why: 処理対象をWorkflowログとCodex入力の両方で明確にするため。
+   - Dependencies: ステップ1
+   - Risk: 低
+
+3. **Issueコメント投稿** (File: `.github/workflows/issue-requirements-plan.yaml`)
+   - Action: Codexの最終出力をIssueコメントへ投稿する。
+   - Why: 要件と受入条件の整理結果をIssue上に残すため。
+   - Dependencies: ステップ2
+   - Risk: 低
+
+### フェーズ2: 実装PRフローの事前確認
+
+1. **Issue本文チェックの追加** (File: `.github/workflows/issue-driven-pr.yaml`)
+   - Action: `codex-autofix`実行前に要件・受入条件の見出しがあるか確認する。
+   - Why: 不十分なIssue本文を前提に実装PR作成へ進ませないため。
    - Dependencies: なし
    - Risk: 中
 
-2. **接続別snapshotを生成する** (File: `src/durable-objects/room-events.ts`)
-   - Action: SSEクライアントごとに回答済み質問IDを保持し、`snapshotForAudience` へ渡す
-   - Why: 同じroomの参加者ごとに異なる結果公開範囲を適用するため
+2. **不足時コメント** (File: `.github/workflows/issue-driven-pr.yaml`)
+   - Action: 不足している見出しと`codex-plan`ラベル利用をIssueコメントで案内する。
+   - Why: 次に必要な作業をメンテナーが判断できるようにするため。
    - Dependencies: ステップ1
-   - Risk: 中
-
-3. **クライアント再取得を廃止する** (File: `src/client/pages/room-page.tsx`)
-   - Action: SSE snapshotを直接反映し、投票成功後のみEventSourceを再接続する
-   - Why: 参加者数と投票数に比例するルームAPI再取得を除去するため
-   - Dependencies: ステップ1、2
-   - Risk: 中
-
-### フェーズ2: 検証
-
-1. **Workerテストを追加する** (File: `tests/worker/voting-flow.test.ts`)
-   - Action: 回答済み結果だけがSSE配信され、その後の投票でリアルタイム更新されることを検証する
-   - Why: サーバー側の公開範囲を保証するため
-   - Dependencies: フェーズ1
-   - Risk: 中
-
-2. **E2Eテストを追加する** (File: `tests/e2e/room.spec.ts`)
-   - Action: 投票後のSSE通知で参加者ルームAPIのGET回数が増えないことを検証する
-   - Why: 再取得増幅の回帰を防ぐため
-   - Dependencies: フェーズ1
-   - Risk: 中
-
-3. **全品質チェックを実行する** (File: repository-wide)
-   - Action: `pnpm check`, `pnpm test`, `pnpm test:e2e`, `pnpm build` を実行する
-   - Why: 型、配信、投票フロー、ビルドへの回帰がないことを確認するため
-   - Dependencies: フェーズ2
-   - Risk: 中
+   - Risk: 低
 
 ## テスト戦略
 
-- ユニットテスト: 既存の `snapshotForAudience` 公開範囲テストを維持する
-- Workerテスト: Cookie由来の回答済み質問だけをSSEで公開し、票数更新を受信する
-- E2Eテスト: 投票後のSSE更新でルームAPI再取得が発生しないことを数える
-- 全体検証: check、test、E2E、build
+- 静的検証: `pnpm check`
+- ユニットテスト: `pnpm test`
+- ビルド: `pnpm build`
+- 手動確認: Workflow YAMLのトリガー、条件分岐、Issueコンテキスト参照を確認する。
 
 ## リスクと対策
 
-- **Risk**: 投票直後に古い公開範囲のSSEがPOSTレスポンスを上書きする
-  - Mitigation: 古いEventSourceを無効化してからPOST snapshotを反映し、新しい公開範囲で再接続する
-- **Risk**: 回答済み質問IDをクエリ改ざんされる
-  - Mitigation: 公開URLの入力を使わず、WorkerがCookieとD1から決定してDO内部URLへ渡す
-- **Risk**: host接続で結果が欠落する
-  - Mitigation: host audienceは従来どおり全snapshotを返し、Workerテストで確認する
+- **Risk**: `codex-autofix`の既存運用で要件・受入条件見出しがないIssueが止まる。
+  - Mitigation: 不足時コメントで`codex-plan`ラベル付与を案内し、実装前の要件整理に誘導する。
 
 ## 成功基準
 
-- [x] SSE受信時に参加者ルームAPIを再取得しない
-- [x] 回答済み質問の結果がSSEで更新される
-- [x] 未回答質問の結果がSSEに含まれない
-- [x] ホストのリアルタイム更新が維持される
-- [x] `pnpm check`, `pnpm test`, `pnpm test:e2e`, `pnpm build` が成功する
+- [x] `codex-plan`ラベル付与で要件定義Workflowが起動する。
+- [x] Issue番号、URL、タイトル、本文が処理へ渡る。
+- [x] 整理結果がIssueコメントに残る。
+- [x] `codex-autofix`と`codex-plan`の責務が分離される。
+- [x] 要件・受入条件が不足するIssueでは`codex-autofix`が実装へ進まない。


### PR DESCRIPTION
## Summary

- Add a dedicated `codex-plan` issue workflow that runs on issue creation or `codex-plan` label assignment.
- Pass issue number, URL, title, and body into the requirements planning prompt and post the result as an issue comment.
- Add a readiness guard to the existing `codex-autofix` workflow so implementation is skipped when required planning sections are missing.

Closes #47

## Verification

- `pnpm check`
- `pnpm test`
- `pnpm build`
- `pnpm test:e2e` (after creating local `.dev.vars` from `.dev.vars.example` for Turnstile test settings)
- YAML parse check with Ruby `YAML.load_file` for `.github/workflows/*.yaml`