### PR TITLE
Stop host SSE streams when sessions expire

### DIFF
--- a/docs/skill-output/PLAN.md
+++ b/docs/skill-output/PLAN.md
@@ -1,74 +1,69 @@
-# 実装計画: Issue要件定義ワークフロー
+# 実装計画: ホストSSEのセッション期限終了
 
 ## 概要
 
-Issue #47では、実装前にIssueの要件と受入条件を整理する自動処理を追加する。既存の`codex-autofix`による実装PR作成とは別の`codex-plan`トリガーを用意し、要件定義と実装開始の責務を分離する。
+Issue #39では、接続開始後にホストセッション期限をまたいだSSE接続がホスト向けsnapshotを受け続ける問題を修正する。今回は第一対応として、接続開始時に検証済みホストセッションの`expires_at`をDurable Objectへ渡し、期限到達時にホストSSEストリームを終了する。
 
 ## 要件
 
-- Issue作成時、または`codex-plan`ラベル付与時に要件定義処理を起動する。
-- 対象Issueの番号、URL、タイトル、本文をCodex処理へ渡す。
-- 整理された要件、受入条件、不足点をIssueコメントとして残す。
-- `codex-autofix`の実装PR作成フローとトリガーを混同しない。
-- 不十分なIssue本文で`codex-autofix`が不用意に実装へ進まないようにする。
+- SSE接続開始時にWorkerで検証したホストセッションの`expires_at`をDOへ渡す。
+- DOはホスト接続だけ期限タイマーを持ち、期限到達時にストリームを閉じる。
+- ストリーム終了後の再接続ではWorkerがCookieを再検証し、期限切れなら参加者として接続する。
+- 有効なホストと参加者向けの既存SSE配信は維持する。
+- 期限切れ後にホスト向けsnapshotが配信されないことをWorker/APIレベルで確認する。
 
 ## アーキテクチャ変更
 
-- `.github/workflows/issue-requirements-plan.yaml`: `opened`または`codex-plan`ラベルを契機に、要件定義専用のCodex実行とIssueコメント投稿を行う。
-- `.github/workflows/issue-driven-pr.yaml`: 実装前にIssue本文が要件・受入条件を含むか確認し、不足時はコメントして実装をスキップする。
+- `src/server/index.ts`: SSEルートでホスト認証結果の`expires_at`を取得し、ホスト接続時だけDOのURLへ渡す。
+- `src/durable-objects/room-events.ts`: `SseClient`に期限タイマーを保持し、ホストセッション期限到達時にストリームを閉じる。
+- `tests/worker/voting-flow.test.ts`: 期限が近いホストセッションでSSE接続し、期限後にストリームが閉じ、再接続が参加者snapshotになることを確認する。
 
 ## 実装手順
 
-### フェーズ1: 要件定義ワークフロー追加
+### フェーズ1: Workerの認証情報拡張
 
-1. **専用Workflowの作成** (File: `.github/workflows/issue-requirements-plan.yaml`)
-   - Action: `issues.opened`と`issues.labeled`を監視し、`opened`または`codex-plan`ラベル時だけ実行する。
-   - Why: Issue作成と要件定義ラベルの両方を入口にできるようにするため。
+1. **認証ヘルパー追加** (File: `src/server/index.ts`)
+   - Action: `getAuthorizedHostSession()`を追加し、既存の`isAuthorizedHost()`はそのbooleanラッパーにする。
+   - Why: 既存のホスト権限チェック呼び出しを保ちながら、SSEルートだけ期限情報を使えるようにするため。
    - Dependencies: なし
    - Risk: 低
 
-2. **Codex入力の明示化** (File: `.github/workflows/issue-requirements-plan.yaml`)
-   - Action: Issue番号、URL、タイトル、本文を環境変数経由でプロンプトに含める。
-   - Why: 処理対象をWorkflowログとCodex入力の両方で明確にするため。
+2. **SSE URLへ期限を追加** (File: `src/server/index.ts`)
+   - Action: ホストとして認証された場合に`hostSessionExpiresAt`クエリをDOへ渡す。
+   - Why: DOがD1へアクセスせずに期限到達を判断できるようにするため。
    - Dependencies: ステップ1
    - Risk: 低
 
-3. **Issueコメント投稿** (File: `.github/workflows/issue-requirements-plan.yaml`)
-   - Action: Codexの最終出力をIssueコメントへ投稿する。
-   - Why: 要件と受入条件の整理結果をIssue上に残すため。
-   - Dependencies: ステップ2
-   - Risk: 低
+### フェーズ2: DOの接続終了制御
 
-### フェーズ2: 実装PRフローの事前確認
-
-1. **Issue本文チェックの追加** (File: `.github/workflows/issue-driven-pr.yaml`)
-   - Action: `codex-autofix`実行前に要件・受入条件の見出しがあるか確認する。
-   - Why: 不十分なIssue本文を前提に実装PR作成へ進ませないため。
-   - Dependencies: なし
+1. **期限タイマー管理** (File: `src/durable-objects/room-events.ts`)
+   - Action: ホスト接続だけ`setTimeout`を設定し、期限到達時に`controller.close()`してクライアントを削除する。
+   - Why: 期限切れ後のbroadcast対象からホスト接続を外すため。
+   - Dependencies: フェーズ1
    - Risk: 中
 
-2. **不足時コメント** (File: `.github/workflows/issue-driven-pr.yaml`)
-   - Action: 不足している見出しと`codex-plan`ラベル利用をIssueコメントで案内する。
-   - Why: 次に必要な作業をメンテナーが判断できるようにするため。
+2. **後始末の一元化** (File: `src/durable-objects/room-events.ts`)
+   - Action: abort/cancel/enqueue失敗/期限到達の全経路でタイマーを解除する。
+   - Why: 接続終了後に不要なタイマーが残らないようにするため。
    - Dependencies: ステップ1
    - Risk: 低
 
 ## テスト戦略
 
+- ユニット/Workerテスト: `tests/worker/voting-flow.test.ts`に期限到達後のホストSSE終了と再接続時の参加者snapshotを追加する。
 - 静的検証: `pnpm check`
-- ユニットテスト: `pnpm test`
-- ビルド: `pnpm build`
-- 手動確認: Workflow YAMLのトリガー、条件分岐、Issueコンテキスト参照を確認する。
+- 全体検証: `pnpm test`、`pnpm test:e2e`、`pnpm build`
 
 ## リスクと対策
 
-- **Risk**: `codex-autofix`の既存運用で要件・受入条件見出しがないIssueが止まる。
-  - Mitigation: 不足時コメントで`codex-plan`ラベル付与を案内し、実装前の要件整理に誘導する。
+- **Risk**: 期限到達と初期snapshot送信の境界で期限切れホストへsnapshotが送られる。
+  - Mitigation: DO側で期限が過去または無効な場合は即時終了し、Worker側でも期限切れセッションはホスト扱いしない。
+- **Risk**: タイマー終了後もclient集合に残りbroadcastされる。
+  - Mitigation: `closeClient()`経由でcontroller close、タイマー解除、集合削除をまとめる。
 
 ## 成功基準
 
-- [x] `codex-plan`ラベル付与で要件定義Workflowが起動する。
-- [x] Issue番号、URL、タイトル、本文が処理へ渡る。
-- [x] 整理結果がIssueコメントに残る。
-- [x] `codex-autofix`と`codex-plan`の責務が分離される。
-- [x] 要件・受入条件が不足するIssueでは`codex-autofix`が実装へ進まない。
+- [ ] ホストSSE接続が`expires_at`到達時に終了する。
+- [ ] 期限終了後の同じCookieでの再接続は参加者向けsnapshotになる。
+- [ ] 参加者SSEと有効なホストSSEの既存挙動が維持される。
+- [ ] 自動テストとビルドが通る。

--- a/src/durable-objects/room-events.ts
+++ b/src/durable-objects/room-events.ts
@@ -11,6 +11,7 @@ const HEARTBEAT_INTERVAL_MS = 15_000;
 interface SseClient {
   audience: SnapshotAudience;
   controller: ReadableStreamDefaultController<Uint8Array>;
+  expiryTimer?: ReturnType<typeof setTimeout>;
   visibleResultQuestionIds: string[];
 }
 
@@ -34,6 +35,7 @@ export class RoomEventsDO implements DurableObject {
       return this.createEventStream(
         request,
         this.readAudience(url),
+        url.searchParams.get("hostSessionExpiresAt"),
         url.searchParams.getAll("visibleResultQuestionId"),
       );
     }
@@ -52,6 +54,7 @@ export class RoomEventsDO implements DurableObject {
   private createEventStream(
     request: Request,
     audience: SnapshotAudience,
+    hostSessionExpiresAt: string | null,
     visibleResultQuestionIds: string[],
   ): Response {
     let client: SseClient | undefined;
@@ -60,6 +63,12 @@ export class RoomEventsDO implements DurableObject {
       start: (controller) => {
         client = { audience, controller, visibleResultQuestionIds };
         this.clients.add(client);
+
+        if (!this.startHostSessionExpiryTimer(client, hostSessionExpiresAt)) {
+          this.closeClient(client);
+          return;
+        }
+
         this.startHeartbeat();
 
         this.enqueue(controller, "retry: 3000\n\n");
@@ -151,6 +160,34 @@ export class RoomEventsDO implements DurableObject {
     }
   }
 
+  private startHostSessionExpiryTimer(client: SseClient, expiresAt: string | null): boolean {
+    if (client.audience !== "host") {
+      return true;
+    }
+
+    if (!expiresAt) {
+      return false;
+    }
+
+    const expiresAtTime = Date.parse(expiresAt);
+
+    if (Number.isNaN(expiresAtTime)) {
+      return false;
+    }
+
+    const delayMs = expiresAtTime - Date.now();
+
+    if (delayMs <= 0) {
+      return false;
+    }
+
+    client.expiryTimer = setTimeout(() => {
+      this.closeClient(client);
+    }, delayMs);
+
+    return true;
+  }
+
   private startHeartbeat(): void {
     if (this.heartbeatTimer) {
       return;
@@ -165,7 +202,22 @@ export class RoomEventsDO implements DurableObject {
     }, HEARTBEAT_INTERVAL_MS);
   }
 
+  private closeClient(client: SseClient): void {
+    try {
+      client.controller.close();
+    } catch {
+      // The stream may already be closed by the peer.
+    }
+
+    this.removeClient(client);
+  }
+
   private removeClient(client: SseClient): void {
+    if (client.expiryTimer) {
+      clearTimeout(client.expiryTimer);
+      client.expiryTimer = undefined;
+    }
+
     this.clients.delete(client);
 
     if (this.clients.size === 0 && this.heartbeatTimer) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -897,12 +897,17 @@ app.get(
 
     await notifyRoomSnapshot(c.env, roomState.snapshot);
 
-    const audience = (await isAuthorizedHost(c, roomId)) ? "host" : "participant";
+    const hostSession = await getAuthorizedHostSession(c, roomId);
+    const audience = hostSession ? "host" : "participant";
     const visibleResultQuestionIds =
       audience === "participant" ? await getParticipantVotedQuestionIds(c, roomId) : [];
     const roomEvents = c.env.ROOM_EVENTS.getByName(roomId);
     const eventsUrl = new URL("https://room-events/events");
     eventsUrl.searchParams.set("audience", audience);
+
+    if (hostSession) {
+      eventsUrl.searchParams.set("hostSessionExpiresAt", hostSession.expiresAt);
+    }
 
     for (const questionId of visibleResultQuestionIds) {
       eventsUrl.searchParams.append("visibleResultQuestionId", questionId);
@@ -925,15 +930,22 @@ app.onError((error, c) => {
 });
 
 async function isAuthorizedHost(c: AppContext, roomId: string): Promise<boolean> {
+  return Boolean(await getAuthorizedHostSession(c, roomId));
+}
+
+async function getAuthorizedHostSession(
+  c: AppContext,
+  roomId: string,
+): Promise<{ id: string; expiresAt: string } | null> {
   const token = getHostSessionToken(c, roomId);
 
   if (!token) {
-    return false;
+    return null;
   }
 
   const tokenHash = await sha256(token);
   const session = await c.env.DB.prepare(
-    `SELECT id
+    `SELECT id, expires_at AS expiresAt
      FROM host_sessions
      WHERE room_id = ?
        AND token_hash = ?
@@ -942,9 +954,9 @@ async function isAuthorizedHost(c: AppContext, roomId: string): Promise<boolean>
      LIMIT 1`,
   )
     .bind(roomId, tokenHash, new Date().toISOString())
-    .first<{ id: string }>();
+    .first<{ id: string; expiresAt: string }>();
 
-  return Boolean(session);
+  return session ?? null;
 }
 
 function isUniqueConstraintError(error: unknown): boolean {

--- a/tests/worker/voting-flow.test.ts
+++ b/tests/worker/voting-flow.test.ts
@@ -394,6 +394,60 @@ describe("voting flow", () => {
     });
   });
 
+  it("closes host SSE streams when the host session expires", async () => {
+    const createRoomResponse = await SELF.fetch("https://example.com/api/rooms", {
+      body: JSON.stringify({
+        title: "SSE期限テスト",
+        adminPassword: "password123",
+        turnstileToken: "test-token",
+      }),
+      headers: mutationHeaders({ "Content-Type": "application/json" }),
+      method: "POST",
+    });
+
+    expect(createRoomResponse.status).toBe(201);
+    const room = await createRoomResponse.json<{ roomId: string }>();
+    const hostCookie = readCookie(createRoomResponse);
+    const question = await createQuestion(room.roomId, hostCookie, {
+      title: "期限後に見えてはいけない結果",
+      questionType: "single",
+      options: ["A", "B"],
+    });
+    const startResponse = await startQuestion(room.roomId, question.id, hostCookie);
+    expect(startResponse.status).toBe(200);
+
+    const expiresAt = new Date(Date.now() + 1000).toISOString();
+    await testEnv.DB.prepare("UPDATE host_sessions SET expires_at = ? WHERE room_id = ?")
+      .bind(expiresAt, room.roomId)
+      .run();
+
+    const hostEventsResponse = await SELF.fetch(
+      `https://example.com/api/rooms/${room.roomId}/events`,
+      {
+        headers: { Cookie: hostCookie },
+      },
+    );
+    expect(hostEventsResponse.status).toBe(200);
+    const hostEvents = createRoomSnapshotReader(hostEventsResponse);
+    const initialHostEvent = await hostEvents.readSnapshot();
+
+    expect(Object.keys(initialHostEvent.resultsByQuestion)).toEqual([question.id]);
+    await hostEvents.waitForClosed();
+
+    const reconnectedResponse = await SELF.fetch(
+      `https://example.com/api/rooms/${room.roomId}/events`,
+      {
+        headers: { Cookie: hostCookie },
+      },
+    );
+    expect(reconnectedResponse.status).toBe(200);
+    const reconnectedEvents = createRoomSnapshotReader(reconnectedResponse);
+    const reconnectedEvent = await reconnectedEvents.readSnapshot();
+
+    expect(reconnectedEvent.resultsByQuestion).toEqual({});
+    await reconnectedEvents.cancel();
+  });
+
   it("rejects unsafe requests without valid same-origin headers", async () => {
     const requestBody = JSON.stringify({
       title: "不正リクエスト",
@@ -519,6 +573,7 @@ function readCookie(response: Response): string {
 function createRoomSnapshotReader(response: Response): {
   cancel: () => Promise<void>;
   readSnapshot: () => Promise<RoomSnapshot>;
+  waitForClosed: () => Promise<void>;
 } {
   if (!response.body) {
     throw new Error("SSE response body was not returned");
@@ -562,6 +617,24 @@ function createRoomSnapshotReader(response: Response): {
 
         buffer += decoder.decode(chunk.value, { stream: true });
       }
+    },
+    waitForClosed: async () => {
+      await Promise.race([
+        (async () => {
+          while (true) {
+            const chunk = await reader.read();
+
+            if (chunk.done) {
+              return;
+            }
+          }
+        })(),
+        new Promise<never>((_, reject) => {
+          setTimeout(() => {
+            reject(new Error("SSE stream did not close before timeout"));
+          }, 3000);
+        }),
+      ]);
     },
   };
 }


### PR DESCRIPTION
## Summary
- Pass the validated host session expires_at from the Worker SSE route to RoomEventsDO
- Close host SSE streams in the Durable Object when that expiry is reached
- Add a Worker/API test that verifies the host stream closes and reconnects as participant after expiry

Closes #39

## Verification
- pnpm check
- pnpm test -- tests/worker/voting-flow.test.ts
- pnpm test
- pnpm build

## E2E
- pnpm test:e2e was run after installing Playwright Chromium, but the existing E2E environment failed because TURNSTILE_SITE_KEY is not configured, leaving the room creation button disabled. One navigation test passed before the Turnstile-dependent tests failed.